### PR TITLE
Sanitize src attribute

### DIFF
--- a/includes/content_filter.php
+++ b/includes/content_filter.php
@@ -100,7 +100,7 @@ class Content_Filter
 				$self->user_settings = $self->custom_media_queries->get_settings();
 			}
 
-			$src = $settings['attributes']['img']['src'];
+			$src = (isset($settings['attributes']['img']['src'])) ? $settings['attributes']['img']['src'] : '';
 			$settings['notBiggerThan'] = $src;
 			// We don't wanna have an src attribute on the <img>
 			unset($settings['attributes']['img']['src']);


### PR DESCRIPTION
Prevent php notices when setting the src attribute i.e. when there is a srcset but no src attribute.