### PR TITLE
Added scope attribute to style-tag for validation

### DIFF
--- a/includes/style.php
+++ b/includes/style.php
@@ -11,7 +11,7 @@ class Style extends Create_Responsive_image
 
 	protected function build_css($selector)
 	{
-		$css = '<style>';
+		$css = '<style scoped>';
 			$css .= $selector . ' {';
 				$css .= 'background-image: url("'.$this->images[0]['src'].'");';
 			$css .= '}';


### PR DESCRIPTION
The style-tag needs a scoped attribute to validate in HTML5. See issue #23 
